### PR TITLE
Add a GitHub Action to publish to PyPi on Release publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,50 @@
+# This workflow will upload a Python Package to PyPi when a Release is created
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  PYPI_USERNAME: __token__
+  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  CODE_ANALYZER_VERSION: "20240923T182840"
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python - -y
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install package dependencies
+        run: |
+          poetry config virtualenvs.create false
+          poetry install --sync --no-interaction
+
+      - name: Get Code Analyzer
+        run: |
+          wget -q https://github.com/IBM/codenet-minerva-code-analyzer/releases/download/$CODE_ANALYZER_VERSION/codeanalyzer.jar
+          echo "Moving codeanalyzer.jar to:" ${{ github.workspace }}/cldk/analysis/java/codeanalyzer/jar/codeanalyzer.jar
+          mv codeanalyzer.jar ${{ github.workspace }}/cldk/analysis/java/codeanalyzer/jar/codeanalyzer.jar
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish package distributions to PyPI
+        run: poetry publish --username $PYPI_USERNAME --password $PYPI_PASSWORD

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Documentation](https://img.shields.io/badge/GitHub%20Pages-Docs-blue)](https://ibm.github.io/codellm-devkit/)
+[![PyPI version](https://badge.fury.io/py/cldk.svg)](https://badge.fury.io/py/cldk)
 
 Codellm-devkit (CLDK) is a multilingual program analysis framework that bridges the gap between traditional static analysis tools and Large Language Models (LLMs) specialized for code (CodeLLMs). Codellm-devkit allows developers to streamline the process of transforming raw code into actionable insights by providing a unified interface for integrating outputs from various analysis tools and preparing them for effective use by CodeLLMs.
 


### PR DESCRIPTION
Made the following changes:

- Added a GitHub Action called: `python-publish.yml` to publish to PyPi whenever a new release is created on GitHub
- Added a PyPi badge to the `README.md` file which shows version and links to PyPi

**Note:** This will automatically create a Python package and publish it to PyPi every time a new Release is created in GitHub. The version will be based on the version in the `pyproject.toml` file so be sure to make the git `tag` and GitHub release version match the project version.