### PR TITLE
feat: Add inheritance support to Java call graph generation using symbol table

### DIFF
--- a/cldk/analysis/java/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/java/codeanalyzer/codeanalyzer.py
@@ -756,14 +756,17 @@ class JCodeanalyzer:
                         callee_signature = call_site.callee_signature
 
                     if call_site.receiver_type != "":
-                        # call to any class
+                        # call to any class - check if the target method exists in receiver type hierarchy
                         if self.get_class(qualified_class_name=call_site.receiver_type):
-                            if callee_signature == target_method_signature and call_site.receiver_type == target_class_name:
+                            # Use hierarchy search to find the method (including inherited methods)
+                            found_method, found_class = self.__find_method_in_hierarchy(call_site.receiver_type, callee_signature)
+                            if found_method is not None and callee_signature == target_method_signature and found_class == target_class_name:
                                 source_method_details = self.get_method(method_signature=method, qualified_class_name=class_name)
                                 source_class = class_name
                     else:
-                        # check if any method exists with the signature in the class even if the receiver type is blank
-                        if callee_signature == target_method_signature and class_name == target_class_name:
+                        # check if any method exists with the signature in the class (including inherited) even if the receiver type is blank
+                        found_method, found_class = self.__find_method_in_hierarchy(class_name, callee_signature)
+                        if found_method is not None and callee_signature == target_method_signature and found_class == target_class_name:
                             source_method_details = self.get_method(method_signature=method, qualified_class_name=class_name)
                             source_class = class_name
 
@@ -781,6 +784,46 @@ class JCodeanalyzer:
                         if call_edge not in cg:
                             cg.append(call_edge)
         return cg
+
+    def __find_method_in_hierarchy(self, qualified_class_name: str, method_signature: str) -> Tuple[JCallable | None, str]:
+        """Finds a method in the class hierarchy (including inherited methods).
+        
+        Ignores interface methods and only returns concrete implementations.
+
+        Args:
+            qualified_class_name (str): The qualified class name to start searching from.
+            method_signature (str): The method signature to find.
+
+        Returns:
+            Tuple[JCallable | None, str]: A tuple of (method_details, declaring_class).
+                Returns (None, "") if the method is not found.
+        """
+        # First, check if the method exists in the current class
+        klass = self.get_class(qualified_class_name=qualified_class_name)
+        method_details = self.get_method(method_signature=method_signature, qualified_class_name=qualified_class_name)
+        
+        # If found and it's not an interface, return it (concrete implementation)
+        if method_details is not None and klass is not None and not klass.is_interface:
+            return method_details, qualified_class_name
+
+        # If not found or is an interface, check parent classes (extends) first
+        # This ensures we find concrete implementations before interface methods
+        if klass is not None:
+            # Check extended classes (these are more likely to have concrete implementations)
+            for parent_class in klass.extends_list:
+                parent_method, found_class = self.__find_method_in_hierarchy(parent_class, method_signature)
+                if parent_method is not None:
+                    return parent_method, found_class
+
+            # Only check implemented interfaces if no concrete implementation was found
+            # This is a fallback for cases where only the interface method exists
+            # for interface in klass.implements_list:
+            #     interface_method, found_class = self.__find_method_in_hierarchy(interface, method_signature)
+            #     if interface_method is not None:
+            #         return interface_method, found_class
+
+        # Do not return interface methods - only concrete implementations are included in call graph
+        return None, ""
 
     def __raw_call_graph_using_symbol_table(self, qualified_class_name: str, method_signature: str, cg=None) -> list[JGraphEdgesST]:
         """Generates a call graph using symbol table information.
@@ -826,16 +869,17 @@ class JCodeanalyzer:
             if call_site.receiver_type != "":
                 # call to any class
                 if self.get_class(qualified_class_name=call_site.receiver_type):
-                    tmd = self.get_method(method_signature=callee_signature, qualified_class_name=call_site.receiver_type)
+                    # Check for method in the receiver type and its hierarchy
+                    tmd, found_class = self.__find_method_in_hierarchy(call_site.receiver_type, callee_signature)
                     if tmd is not None:
                         target_method_details = tmd
-                        target_class = call_site.receiver_type
+                        target_class = found_class
             else:
-                # check if any method exists with the signature in the class even if the receiver type is blank
-                tmd = self.get_method(method_signature=callee_signature, qualified_class_name=qualified_class_name)
+                # check if any method exists with the signature in the class (including inherited) even if the receiver type is blank
+                tmd, found_class = self.__find_method_in_hierarchy(qualified_class_name, callee_signature)
                 if tmd is not None:
                     target_method_details = tmd
-                    target_class = qualified_class_name
+                    target_class = found_class
 
             if target_class != "" and target_method_details is not None:
                 source: JMethodDetail

--- a/tests/analysis/java/test_inheritance_call_graph.py
+++ b/tests/analysis/java/test_inheritance_call_graph.py
@@ -1,0 +1,418 @@
+"""
+Test cases for inheritance support in __raw_call_graph_using_symbol_table method.
+
+These tests verify that the call graph correctly identifies inherited methods
+when building the call graph using the symbol table.
+"""
+
+import pytest
+from cldk import CLDK
+from cldk.analysis import AnalysisLevel
+
+
+class TestInheritanceCallGraphIntegration:
+    """Test suite for inheritance support in call graph generation."""
+
+    def test_call_graph_with_inherited_method_from_parent_class(self):
+        """Test that call graph includes inherited methods from parent classes."""
+        java_code = """
+        package com.example;
+        
+        class Parent {
+            public void inheritedMethod() {
+                System.out.println("Parent method");
+            }
+        }
+        
+        class Child extends Parent {
+            public void callerMethod() {
+                this.inheritedMethod();
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get call graph using symbol table
+        call_graph_edges = java_analysis.backend.get_class_call_graph_using_symbol_table(
+            qualified_class_name="com.example.Child",
+            method_signature="callerMethod()"
+        )
+        
+        # Verify that the call to inheritedMethod is captured
+        assert len(call_graph_edges) > 0
+        
+        # Find the edge for the inherited method call
+        found_inherited_call = False
+        for source, target in call_graph_edges:
+            if (source.klass == "com.example.Child" and 
+                source.method.signature == "callerMethod()" and
+                target.method.signature == "inheritedMethod()"):
+                # The target should be the Parent class where the method is defined
+                assert target.klass == "com.example.Parent"
+                found_inherited_call = True
+                break
+        
+        assert found_inherited_call, "Call to inherited method not found in call graph"
+
+    def test_call_graph_prefers_concrete_implementation_over_interface(self):
+        """Test that concrete implementation is preferred over interface method."""
+        java_code = """
+        package com.example;
+        
+        interface MyInterface {
+            void sharedMethod();
+        }
+        
+        class ConcreteClass implements MyInterface {
+            public void sharedMethod() {
+                System.out.println("Concrete implementation");
+            }
+            
+            public void callerMethod() {
+                this.sharedMethod();
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get call graph using symbol table
+        call_graph_edges = java_analysis.backend.get_class_call_graph_using_symbol_table(
+            qualified_class_name="com.example.ConcreteClass",
+            method_signature="callerMethod()"
+        )
+        
+        # Verify that the call points to the concrete implementation, not the interface
+        found_concrete_call = False
+        for source, target in call_graph_edges:
+            if (source.klass == "com.example.ConcreteClass" and 
+                source.method.signature == "callerMethod()" and
+                target.method.signature == "sharedMethod()"):
+                # The target should be the concrete class, not the interface
+                assert target.klass == "com.example.ConcreteClass"
+                assert target.klass != "com.example.MyInterface"
+                found_concrete_call = True
+                break
+        
+        assert found_concrete_call, "Call to concrete implementation not found in call graph"
+
+    def test_call_graph_with_multi_level_inheritance(self):
+        """Test that call graph handles multi-level inheritance correctly with parameterized methods."""
+        java_code = """
+        package com.example;
+        
+        class Grandparent {
+            public void grandparentMethod(String message, int count) {
+                System.out.println("Grandparent method: " + message + " x " + count);
+            }
+        }
+        
+        class Parent extends Grandparent {
+            public void parentMethod(String text) {
+                System.out.println("Parent method: " + text);
+            }
+        }
+        
+        class Child extends Parent {
+            public void callerMethod() {
+                // Call inherited method from grandparent with parameters
+                this.grandparentMethod("hello", 5);
+                // Call inherited method from parent with parameter
+                this.parentMethod("world");
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get call graph using symbol table
+        call_graph_edges = java_analysis.backend.get_class_call_graph_using_symbol_table(
+            qualified_class_name="com.example.Child",
+            method_signature="callerMethod()"
+        )
+        
+        # Verify both method calls are captured
+        assert len(call_graph_edges) >= 2
+        
+        found_grandparent_call = False
+        found_parent_call = False
+        for source, target in call_graph_edges:
+            if (source.klass == "com.example.Child" and
+                source.method.signature == "callerMethod()"):
+                if "grandparentMethod" in target.method.signature:
+                    assert target.klass == "com.example.Grandparent"
+                    found_grandparent_call = True
+                elif "parentMethod" in target.method.signature:
+                    assert target.klass == "com.example.Parent"
+                    found_parent_call = True
+        
+        assert found_grandparent_call, "Call to grandparent method not found"
+        assert found_parent_call, "Call to parent method not found"
+
+    def test_get_all_callees_with_inherited_methods(self):
+        """Test get_all_callees includes inherited method calls."""
+        java_code = """
+        package com.example;
+        
+        class Parent {
+            public void inheritedMethod() {
+                System.out.println("Parent method");
+            }
+        }
+        
+        class Child extends Parent {
+            public void callerMethod() {
+                this.inheritedMethod();
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get all callees using symbol table
+        callees = java_analysis.backend.get_all_callees(
+            source_class_name="com.example.Child",
+            source_method_signature="callerMethod()",
+            using_symbol_table=True
+        )
+        
+        # Verify the inherited method is in the callees
+        assert "callee_details" in callees
+        assert len(callees["callee_details"]) > 0
+        
+        found_inherited_callee = False
+        for callee in callees["callee_details"]:
+            if callee["callee_method"].method.signature == "inheritedMethod()":
+                # Should point to Parent class where method is defined
+                assert callee["callee_method"].klass == "com.example.Parent"
+                found_inherited_callee = True
+                break
+        
+        assert found_inherited_callee, "Inherited method not found in callees"
+
+    def test_get_all_callers_with_inherited_methods(self):
+        """Test get_all_callers works with inherited method calls."""
+        java_code = """
+        package com.example;
+        
+        class Parent {
+            public void targetMethod() {
+                System.out.println("Target method");
+            }
+        }
+        
+        class Child extends Parent {
+            public void callerMethod() {
+                this.targetMethod();
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get all callers of the parent method using symbol table
+        callers = java_analysis.backend.get_all_callers(
+            target_class_name="com.example.Parent",
+            target_method_signature="targetMethod()",
+            using_symbol_table=True
+        )
+        
+        # Verify the child class caller is found
+        assert "caller_details" in callers
+        assert len(callers["caller_details"]) > 0
+        
+        found_child_caller = False
+        for caller in callers["caller_details"]:
+            if (caller["caller_method"].klass == "com.example.Child" and
+                caller["caller_method"].method.signature == "callerMethod()"):
+                found_child_caller = True
+                break
+        
+        assert found_child_caller, "Child class caller not found"
+
+    def test_get_all_callers_with_multi_level_inheritance(self):
+        """Test that get_all_callers works correctly with multi-level inheritance.
+        
+        This specifically tests the __raw_call_graph_using_symbol_table_target_method
+        which is used when is_target_method=True.
+        """
+        java_code = """
+        package com.example;
+        
+        class GrandParent {
+            public void targetMethod() {
+                System.out.println("GrandParent method");
+            }
+        }
+        
+        class Parent extends GrandParent {
+            // Inherits targetMethod from GrandParent
+        }
+        
+        class Child extends Parent {
+            // Inherits targetMethod from Parent (which inherited from GrandParent)
+            
+            public void callInheritedMethod() {
+                this.targetMethod();  // Calls inherited method from GrandParent
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get all callers of the grandparent method using symbol table
+        # This should find Child.callInheritedMethod even though it's calling via inheritance
+        callers = java_analysis.backend.get_all_callers(
+            target_class_name="com.example.GrandParent",
+            target_method_signature="targetMethod()",
+            using_symbol_table=True
+        )
+        
+        # Verify the caller is found
+        assert "caller_details" in callers
+        assert len(callers["caller_details"]) > 0
+        
+        found_child_caller = False
+        for caller in callers["caller_details"]:
+            if (caller["caller_method"].klass == "com.example.Child" and
+                caller["caller_method"].method.signature == "callInheritedMethod()"):
+                found_child_caller = True
+                break
+        
+        assert found_child_caller, "Child class caller not found when calling inherited method"
+
+    def test_get_all_callees_with_multi_level_inheritance(self):
+        """Test get_all_callees with multi-level inheritance."""
+        java_code = """
+        package com.example;
+        
+        class Grandparent {
+            public void grandparentMethod() {
+                System.out.println("Grandparent method");
+            }
+        }
+        
+        class Parent extends Grandparent {
+            public void parentMethod() {
+                System.out.println("Parent method");
+            }
+        }
+        
+        class Child extends Parent {
+            public void callerMethod() {
+                this.grandparentMethod();  // Inherited from Grandparent
+                this.parentMethod();        // Inherited from Parent
+            }
+        }
+        """
+        
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+        
+        # Get all callees using symbol table
+        callees = java_analysis.backend.get_all_callees(
+            source_class_name="com.example.Child",
+            source_method_signature="callerMethod()",
+            using_symbol_table=True
+        )
+        
+        # Verify both inherited methods are in the callees
+        assert "callee_details" in callees
+        assert len(callees["callee_details"]) >= 2
+        
+        found_grandparent_callee = False
+        found_parent_callee = False
+        
+        for callee in callees["callee_details"]:
+            if callee["callee_method"].method.signature == "grandparentMethod()":
+                # Should point to Grandparent class where method is defined
+                assert callee["callee_method"].klass == "com.example.Grandparent"
+                found_grandparent_callee = True
+            elif callee["callee_method"].method.signature == "parentMethod()":
+                # Should point to Parent class where method is defined
+                assert callee["callee_method"].klass == "com.example.Parent"
+                found_parent_callee = True
+        
+        assert found_grandparent_callee, "Grandparent method not found in callees"
+        assert found_parent_callee, "Parent method not found in callees"
+
+    def test_interface_only_methods_not_in_call_graph(self):
+        """Test that interface methods without concrete implementations are NOT included in call graph.
+
+        This verifies that when only interface methods are available (no concrete implementation),
+        they are excluded from the call graph.
+        """
+        java_code = """
+        package com.example;
+
+        interface MyInterface {
+            void interfaceOnlyMethod();
+        }
+
+        class ImplementingClass implements MyInterface {
+            // Does NOT implement interfaceOnlyMethod - it's abstract
+
+            public void callerMethod() {
+                // Attempting to call interface method without implementation
+                this.interfaceOnlyMethod();
+            }
+        }
+        """
+
+        # Analyze the code
+        java_analysis = CLDK(language="java").analysis(
+            source_code=java_code,
+            analysis_level=AnalysisLevel.symbol_table
+        )
+
+        # Get call graph using symbol table
+        call_graph_edges = java_analysis.backend.get_class_call_graph_using_symbol_table(
+            qualified_class_name="com.example.ImplementingClass",
+            method_signature="callerMethod()"
+        )
+
+        # Verify that the call to interface-only method is NOT in the call graph
+        # Since there's no concrete implementation, it should be excluded
+        found_interface_call = False
+        for source, target in call_graph_edges:
+            if (source.klass == "com.example.ImplementingClass" and
+                    source.method.signature == "callerMethod()" and
+                    target.method.signature == "interfaceOnlyMethod()"):
+                found_interface_call = True
+                break
+
+        assert not found_interface_call, "Interface-only method should NOT be in call graph"
+        # The call graph should be empty or not contain the interface method
+        assert len(call_graph_edges) == 0, "Call graph should be empty when only interface methods are available"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Previously, the Java call graph generation using symbol tables only detected methods declared directly in the receiver type's class. When a method was inherited from a parent class, it would not appear in the call graph, leading to incomplete analysis.

This change enhances `JCodeanalyzer` to recursively search the class hierarchy to find inherited method definitions. This ensures that the call graph contains edges for method calls on inherited methods.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Created 8 tests in `test_inheritance_call_graph.py` covering single-level inheritance, concrete vs interface resolution,
and multi-level inheritance with parameters targeting `JCodeanalyzer` methods `get_class_call_graph_using_symbol_table()`, `get_callees()`, and `get_callers()`.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

This is a backward-compatible enhancement.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Interface methods without concrete implementations are not considered during the search.