### PR TITLE
fix: expand tilde (~) in project_path to prevent silent failures

### DIFF
--- a/cldk/analysis/python/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/python/codeanalyzer/codeanalyzer.py
@@ -80,7 +80,10 @@ class PyCodeanalyzer:
     ) -> None:
         if project_dir is None:
             raise ValueError("project_dir is required for Python analysis.")
-        self.project_dir = Path(project_dir)
+        # Expand ~ and resolve to absolute path for robustness
+        self.project_dir = Path(project_dir).expanduser().resolve()
+        if not self.project_dir.is_dir():
+            raise ValueError(f"project_dir does not exist or is not a directory: {self.project_dir}")
         self.analysis_level = analysis_level
         self.eager_analysis = eager_analysis
         self.target_files = target_files
@@ -89,8 +92,8 @@ class PyCodeanalyzer:
         # codeanalyzer-python owns all caching. CLDK forwards these paths
         # verbatim; when cache_dir is None the backend defaults it to
         # <project_dir>/.codeanalyzer.
-        self.cache_dir = Path(cache_dir) if cache_dir else None
-        self.analysis_json_path = Path(analysis_json_path) if analysis_json_path else None
+        self.cache_dir = Path(cache_dir).expanduser().resolve() if cache_dir else None
+        self.analysis_json_path = Path(analysis_json_path).expanduser().resolve() if analysis_json_path else None
 
         self.application: PyApplication = self._run_analyzer()
         # Class-signature → file path lookup, built once.

--- a/cldk/core.py
+++ b/cldk/core.py
@@ -113,6 +113,12 @@ class CLDK:
         if project_path is not None and source_code is not None:
             raise CldkInitializationException("Both project_path and source_code are provided. Please provide " "only one.")
 
+        # Normalize project_path: expand ~ and resolve to absolute path
+        if project_path is not None:
+            project_path = Path(project_path).expanduser().resolve()
+            if not project_path.is_dir():
+                raise CldkInitializationException(f"project_path does not exist or is not a directory: {project_path}")
+
         if self.language == "java":
             return JavaAnalysis(
                 project_dir=project_path,


### PR DESCRIPTION
## Summary

- Paths like `"~/workspace/project"` were not expanded, causing `Path("~/...")` to interpret `~` as a literal directory name
- This led to empty analysis results and spurious `./~/` directories being created

## Changes

- `core.py`: normalize `project_path` with `expanduser().resolve()` and validate directory exists before dispatching to backends
- `codeanalyzer.py`: defensive expansion in `PyCodeanalyzer` for direct instantiation, plus same treatment for `cache_dir`/`analysis_json_path`

## Test plan

- [x] Verified tilde paths now expand correctly
- [x] Verified non-existent paths raise `CldkInitializationException` with clear message