### PR TITLE
ci(release): regenerate docs API reference on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,15 @@ jobs:
 
       - name: Publish package distributions to PyPI
         run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Trigger docs API-reference update
+        # After a successful release, tell the docs repo to regenerate and PR the
+        # Python API reference against this tag. Requires a DOCS_DISPATCH_TOKEN
+        # secret: a PAT (or fine-grained token) with contents:write on
+        # codellm-devkit/docs. See docs-astro .github/workflows/update-api-docs.yml.
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          repository: codellm-devkit/docs
+          event-type: sdk-release
+          client-payload: '{"ref": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## What

After a successful release (GitHub release + PyPI publish), send a `repository_dispatch` (`event-type: sdk-release`) to [`codellm-devkit/docs`](https://github.com/codellm-devkit/docs) carrying the released tag in `client_payload.ref`.

The docs repo listens for this event (`.github/workflows/update-api-docs.yml`), clones this SDK at the released tag, regenerates the Python API reference with `griffe` (`scripts/gen_api_docs.py`), and opens a PR when the generated reference changed — keeping the source-controlled docs version-matched to each release.

## Why

The docs `deploy.yml` already regenerates the reference *ephemerally* for the published site, but never commits it back, so the source-controlled `reference/python-api/*.md` drifts from the SDK. This closes that gap automatically, on release only (no cron, no manual step).

## Required before this works

Add a repo secret **`DOCS_DISPATCH_TOKEN`** to this repository: a PAT (or fine-grained token) with **`contents: write`** on `codellm-devkit/docs`. GitHub's default `GITHUB_TOKEN` cannot dispatch across repositories, so without this secret the new step fails on release.

## Trigger flow

`git push tag vX.Y.Z` → this release workflow publishes → dispatch `sdk-release` → docs regenerate + open PR.