### PR TITLE
ci(release): announce releases in repo and org discussions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  discussions: write  # attach the release-linked repo Discussion (Announcements)
 
 jobs:
   release:
@@ -82,12 +83,46 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Release on GitHub
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: dist/*
           body: ${{ steps.gen_changelog.outputs.changelog }}
+          # Auto-open a repo-level Discussion linked to this release, seeded with
+          # the same notes. Requires Discussions enabled and this category to exist.
+          discussion_category_name: Announcements
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Mirror the release announcement into the ORG-level discussions, which are
+      # backed by codellm-devkit/.github. GITHUB_TOKEN can't write cross-repo, so
+      # this uses a PAT (ORG_DISCUSSIONS_TOKEN) with repo scope, and posts via the
+      # createDiscussion GraphQL mutation. The body (the generated changelog) is
+      # passed via env to avoid shell-injection, matching the repo-level post.
+      - name: Announce in org-level discussions (codellm-devkit/.github)
+        continue-on-error: true   # a failed org post must not fail an otherwise-good release
+        env:
+          GH_TOKEN: ${{ secrets.ORG_DISCUSSIONS_TOKEN }}
+          BODY: ${{ steps.gen_changelog.outputs.changelog }}
+        run: |
+          set -uo pipefail
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          OWNER="codellm-devkit"; REPO=".github"; CATEGORY="Announcements"
+          # The mutation needs GraphQL node IDs, not names — resolve them first.
+          RESP=$(gh api graphql \
+            -f query='query($o:String!,$r:String!){repository(owner:$o,name:$r){id discussionCategories(first:25){nodes{id name}}}}' \
+            -f o="$OWNER" -f r="$REPO") \
+            || { echo "::warning::org discussion lookup failed — skipping org announcement."; exit 0; }
+          REPO_ID=$(echo "$RESP" | jq -r '.data.repository.id')
+          CAT_ID=$(echo "$RESP" | jq -r --arg c "$CATEGORY" '.data.repository.discussionCategories.nodes[]|select(.name==$c)|.id')
+          if [[ -z "$REPO_ID" || "$REPO_ID" == "null" || -z "$CAT_ID" ]]; then
+            echo "::warning::could not resolve $OWNER/$REPO discussion category '$CATEGORY' — skipping org announcement."
+            exit 0
+          fi
+          gh api graphql \
+            -f query='mutation($rid:ID!,$cid:ID!,$t:String!,$b:String!){createDiscussion(input:{repositoryId:$rid,categoryId:$cid,title:$t,body:$b}){discussion{url}}}' \
+            -f rid="$REPO_ID" -f cid="$CAT_ID" \
+            -f t="python-sdk v$VERSION" \
+            -f b="$BODY"
 
       - name: Publish package distributions to PyPI
         run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.2.0"
+version = "1.2.1"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Closes #182.

## What
Post each release to GitHub Discussions in **two** places (parity with the other three repos):

- **Repo-level** — add `discussion_category_name: Announcements` to the publish step and `discussions: write` to `permissions:`, and bump `action-gh-release v1 → v2` (v1 is on deprecated Node16; v2 matches the other repos and reliably supports the discussion input). Seeded from the generated changelog.
- **Org-level** — new `continue-on-error` step posting the same changelog into `codellm-devkit/.github` → **Announcements** via `createDiscussion`, authenticated by `ORG_DISCUSSIONS_TOKEN` (body passed via env to avoid shell-injection; version derived from the tag ref).

Also bumps `1.2.0 → 1.2.1` so the next tag exercises it.

## Prerequisites (already done)
- Discussions enabled + `Announcements` on this repo.
- `ORG_DISCUSSIONS_TOKEN` has `repo` scope.