### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.3.0] - 2026-06-27
+
 ### Added
+- **Bulk, field-projected accessors on the Python facade** (`PythonAnalysis`) for enumerating an
+  application set-at-a-time, instead of paying the per-entity reconstruction `get_methods()` does
+  (tens of thousands of round-trips on the Neo4j backend for a large app): `get_callables_overview()`
+  (returns the new `PyCallableOverview` projection), `get_method_bodies(signatures)`,
+  `get_decorated_callables(markers)`, and `get_callsites_for(signatures)`. On the read-only Neo4j
+  backend each is a single projected Cypher query; in-process each is one symbol-table walk. New
+  `PyCallableOverview` model in `cldk.models.python`.
+- **`tsc_only` toggle for the TypeScript backend.** New `TSCodeAnalyzerConfig` backend config exposes
+  `tsc_only`, which passes `--tsc-only` (codeanalyzer-typescript >= 0.4.2) to pin the call graph to
+  the resolver path, replacing reliance on the obsolete `--call-graph-provider both`.
+- **Synthesized anonymous callables for TypeScript.** New `TSSynthesizedCallable` model and
+  `get_synthesized_callables()` on the TypeScript analysis surface expose the Jelly-resolved
+  anonymous-callback endpoints the symbol table never names, so anonymous call-graph edges no longer
+  dangle. Empty under the `tsc`-only resolver.
 - README **Cited By** section highlighting papers that cite CLDK (SAINT, ASTER, RECON, PRAXIS,
   Phaedrus, and others), compiled from Semantic Scholar / OpenAlex citation data.
+
+### Changed
+- The read-only Neo4j Python backend now reuses a single read session across queries instead of
+  opening one per Cypher statement, cutting per-call overhead on the reconstruction path.
+- Bumped `codeanalyzer-typescript` 0.4.0 → 0.4.3.
 
 ## [v1.2.0] - 2026-06-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.2.1"
+version = "1.3.0"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Cuts the **1.3.0** minor release: bumps `pyproject.toml` `1.2.1 → 1.3.0` and promotes the changelog's `[Unreleased]` into a dated `[v1.3.0]` section.

## Motivation and Context
Everything landed on `main` since `v1.2.0` is additive, backward-compatible new public API, so this is a **minor** bump (semver), not a patch. The orphaned `1.2.1` in pyproject was never tagged/released and is superseded.

Changes captured in `[v1.3.0]`:
- **Added** — Python facade bulk/projected accessors (`get_callables_overview`, `get_method_bodies`, `get_decorated_callables`, `get_callsites_for`) + the new `PyCallableOverview` model (#181); TypeScript `tsc_only` toggle via `TSCodeAnalyzerConfig`, and synthesized anonymous callables (`TSSynthesizedCallable`, `get_synthesized_callables`) (#179); README Cited By section.
- **Changed** — Neo4j Python backend reuses a single read session; `codeanalyzer-typescript` 0.4.0 → 0.4.3.

## How Has This Been Tested?
Docs/version-only change — no code touched. The features themselves shipped and were tested under #179 and #181.

## Breaking Changes
None. Minor, backward-compatible release.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Single commit `chore(release): 1.3.0`. Tagging/publishing is left to the release workflow off the merged version bump — this PR does not create a tag.
