### PR TITLE
feat/python: upgrade to codeanalyzer-python 0.3.0, remove CodeQL (1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.4.0] - 2026-06-27
+
 ### Changed
 - **Upgraded `codeanalyzer-python` 0.2.0 → 0.3.0**, which drops CodeQL and uses **PyCG** for
   call-graph construction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Upgraded `codeanalyzer-python` 0.2.0 → 0.3.0**, which drops CodeQL and uses **PyCG** for
+  call-graph construction.
+
+### Removed
+- **`use_codeql` (BREAKING).** Because codeanalyzer-python 0.3.0 removed CodeQL, the `use_codeql`
+  knob no longer maps to anything and is removed from CLDK's public surface: the
+  `PyCodeAnalyzerConfig.use_codeql` field, the deprecated `CLDK(language).analysis(use_codeql=...)`
+  parameter, and the `PyCodeanalyzer(use_codeql=...)` argument. The `CodeQLDatabaseBuildException`
+  and `CodeQLQueryExecutionException` exception classes are removed as well. Call-graph results may
+  differ (PyCG vs CodeQL-augmented Jedi). See #185.
+
 ## [v1.3.0] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 **A unified, multilingual program-analysis SDK for Code LLMs.** CLDK turns raw source code into structured, LLM-ready program facts — symbol tables, call graphs, type hierarchies, and more — behind a single Python API, so you can build analysis-augmented LLM pipelines without wrangling a different static-analysis tool for every language.
 
-Under the hood, CLDK orchestrates mature analysis engines (WALA, Tree-sitter, Jedi, CodeQL, ts-morph) and normalizes their output into consistent, typed [Pydantic](https://docs.pydantic.dev/) models. You get the same ergonomic interface whether you are analyzing Java, Python, or TypeScript.
+Under the hood, CLDK orchestrates mature analysis engines (WALA, Tree-sitter, Jedi, PyCG, ts-morph) and normalizes their output into consistent, typed [Pydantic](https://docs.pydantic.dev/) models. You get the same ergonomic interface whether you are analyzing Java, Python, or TypeScript.
 
 CLDK is:
 
@@ -125,12 +125,12 @@ Each language is analyzed by a dedicated `codeanalyzer-*` engine; CLDK normalize
 | Language | Analysis engine | What it provides |
 | --- | --- | --- |
 | **Java** | [`codeanalyzer-java`](https://github.com/codellm-devkit/codeanalyzer-java) | WALA + JavaParser. Bytecode-level call graphs, type hierarchies, symbol resolution, CRUD-operation and entry-point detection. Optional read-only **Neo4j** graph backend. |
-| **Python** | [`codeanalyzer-python`](https://github.com/codellm-devkit/codeanalyzer-python) | Jedi with optional CodeQL augmentation. Symbol tables, call graphs, and class/method resolution. Optional read-only **Neo4j** graph backend. |
+| **Python** | [`codeanalyzer-python`](https://github.com/codellm-devkit/codeanalyzer-python) | Jedi with PyCG-based call graphs. Symbol tables, call graphs, and class/method resolution. Optional read-only **Neo4j** graph backend. |
 | **TypeScript / JavaScript** | [`codeanalyzer-typescript`](https://github.com/codellm-devkit/codeanalyzer-typescript) | ts-morph with Jelly-based call graphs. Symbols, call graph, types, decorators, and call sites. Optional read-only **Neo4j** graph backend. |
 
 The backend is selected by the **type** of the `backend=` config you pass to a factory: the in-process analyzer (default) or a `Neo4jConnectionConfig` for the read-only graph backend.
 
-> **Analysis cache (Python):** caching is owned by `codeanalyzer-python` — the backend virtualenv, CodeQL database, and analysis cache live under `cache_dir` (default `<project>/.codeanalyzer`). CodeQL is on by default, so the first run is slow (it provisions a CodeQL DB) and later runs reuse a checksum-validated cache. Add the cache directory to your `.gitignore`.
+> **Analysis cache (Python):** caching is owned by `codeanalyzer-python` — the backend virtualenv and analysis cache live under `cache_dir` (default `<project>/.codeanalyzer`). The first run is slower (it provisions the backend virtualenv) and later runs reuse a checksum-validated cache. Add the cache directory to your `.gitignore`.
 
 ## Architecture
 
@@ -147,7 +147,7 @@ graph TD
     A --> T[cldk.analysis.typescript]
 
     J --> EJ[codeanalyzer-java<br/>WALA · JavaParser]
-    P --> EP[codeanalyzer-python<br/>Jedi · CodeQL]
+    P --> EP[codeanalyzer-python<br/>Jedi · PyCG]
     T --> ET[codeanalyzer-typescript<br/>ts-morph · Jelly]
 
     J -. read-only .-> N[(Neo4j)]

--- a/cldk/analysis/commons/backend_config.py
+++ b/cldk/analysis/commons/backend_config.py
@@ -67,11 +67,9 @@ class PyCodeAnalyzerConfig(CodeAnalyzerConfig):
     Adds the Python-only call-graph knobs on top of :class:`CodeAnalyzerConfig`.
 
     Attributes:
-        use_codeql: If ``True`` (default), augment Jedi-based call-graph resolution with CodeQL.
         use_ray: If ``True``, enable Ray-based parallel processing for large projects.
     """
 
-    use_codeql: bool = True
     use_ray: bool = False
 
 

--- a/cldk/analysis/java/codeanalyzer/_jdk.py
+++ b/cldk/analysis/java/codeanalyzer/_jdk.py
@@ -16,9 +16,8 @@
 
 """Fetch + cache a self-contained Temurin JDK to run codeanalyzer.jar.
 
-Mirrors the codeanalyzer-python ``CodeQLLoader`` pattern (download a platform
-archive from a release, extract restoring exec bits, locate the binary), adapted
-for a JDK:
+Follows a platform-binary loader pattern (download a platform archive from a
+release, extract restoring exec bits, locate the binary), adapted for a JDK:
 
   * pinned to an exact Temurin release (reproducible) instead of "latest",
   * SHA256-verified,
@@ -55,7 +54,7 @@ JDK_RELEASE = "jdk-21.0.5+11"
 
 
 class JdkLoader:
-    """Resolve a Temurin JDK from the Adoptium API, mirroring CodeQLLoader."""
+    """Resolve a Temurin JDK from the Adoptium API."""
 
     _API = "https://api.adoptium.net/v3"
 
@@ -131,8 +130,7 @@ class JdkLoader:
 
         logger.info(f"Extracting JDK to {dest}")
         if archive.name.endswith(".zip"):
-            # zipfile.extractall drops the executable bit; copy each stored mode
-            # back (same fix the CodeQL loader applies).
+            # zipfile.extractall drops the executable bit; copy each stored mode back.
             with zipfile.ZipFile(archive) as zf:
                 for info in zf.infolist():
                     out = zf.extract(info, dest)
@@ -160,7 +158,7 @@ def ensure_jdk(java_cache_dir: Path) -> Path:
             cached at ``<java_cache_dir>/jdk/<release>/`` -- the existing per-language
             cache root, not a new location.
 
-    Resolution order (mirrors codeanalyzer-python's ``_ensure_codeql_bin``):
+    Resolution order:
       1. the cached JDK under ``<java_cache_dir>/jdk/<release>/`` -- reused across runs;
       2. a system ``$JAVA_HOME`` that actually has ``jmods`` -- honored verbatim;
       3. otherwise download + extract the pinned Temurin JDK into the cache.

--- a/cldk/analysis/python/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/python/codeanalyzer/codeanalyzer.py
@@ -29,7 +29,7 @@ The backend produces:
 
 The analysis leverages:
     - **Jedi**: For semantic code understanding and symbol resolution.
-    - **CodeQL** (optional): For enhanced call graph resolution.
+    - **PyCG**: For call-graph construction.
     - **Tree-sitter**: For fast syntactic parsing.
 
 Key features:
@@ -111,7 +111,6 @@ class PyCodeanalyzer(PythonAnalysisBackend):
         analysis_level (str): The depth of analysis performed.
         eager_analysis (bool): Whether to force regeneration of caches.
         target_files (List[str] | None): Specific files to analyze.
-        use_codeql (bool): Whether CodeQL is used for call graph enhancement.
         cache_dir (Path | None): Cache directory for the backend.
         analysis_json_path (Path | None): Path for persisting analysis results.
         application (PyApplication): The analyzed application model.
@@ -129,7 +128,6 @@ class PyCodeanalyzer(PythonAnalysisBackend):
         eager_analysis: bool,
         cache_dir: Union[str, Path, None] = None,
         target_files: List[str] | None = None,
-        use_codeql: bool = True,
         use_ray: bool = False,
     ) -> None:
         """Initialize the Python code analyzer and run analysis.
@@ -154,18 +152,15 @@ class PyCodeanalyzer(PythonAnalysisBackend):
                 its analysis from scratch, ignoring any cached results.
                 If ``False``, cached results are reused when available.
             cache_dir: Directory for codeanalyzer-python's caches, including
-                its virtualenv, CodeQL database, and analysis cache files.
-                If ``None``, defaults to ``<project_dir>/.codeanalyzer``.
+                its virtualenv and analysis cache files. If ``None``, defaults
+                to ``<project_dir>/.codeanalyzer``.
             target_files: Optional list of specific files to analyze. Note
                 that codeanalyzer-python currently supports only a single
                 target file; if multiple are provided, only the first is
                 used and a warning is logged.
-            use_codeql: If ``True`` (default), uses CodeQL to enhance call
-                graph resolution beyond what Jedi provides. Set to ``False``
-                for faster analysis without CodeQL.
             use_ray: If ``True``, enables Ray-based parallel processing for
-                analysis. Recommended for very large projects where Jedi/CodeQL
-                analysis would otherwise be slow. Requires Ray to be installed.
+                analysis. Recommended for very large projects where analysis
+                would otherwise be slow. Requires Ray to be installed.
                 Defaults to ``False``.
 
         Raises:
@@ -173,8 +168,7 @@ class PyCodeanalyzer(PythonAnalysisBackend):
 
         Note:
             Analysis is performed synchronously during initialization.
-            For large projects, this may take significant time, especially
-            with ``use_codeql=True``.
+            For large projects, this may take significant time.
         """
         if project_dir is None:
             raise ValueError("project_dir is required for Python analysis.")
@@ -185,7 +179,6 @@ class PyCodeanalyzer(PythonAnalysisBackend):
         self.analysis_level = analysis_level
         self.eager_analysis = eager_analysis
         self.target_files = target_files
-        self.use_codeql = use_codeql
         self.use_ray = use_ray
 
         # codeanalyzer-python owns all caching. CLDK forwards these paths
@@ -234,7 +227,6 @@ class PyCodeanalyzer(PythonAnalysisBackend):
             input=self.project_dir,
             output=self.analysis_json_path,
             format=OutputFormat.JSON,
-            using_codeql=self.use_codeql,
             using_ray=self.use_ray,
             rebuild_analysis=self.eager_analysis,
             skip_tests=True,

--- a/cldk/analysis/python/python_analysis.py
+++ b/cldk/analysis/python/python_analysis.py
@@ -25,8 +25,7 @@ The analysis is powered by the ``codeanalyzer-python`` backend, which uses a
 combination of:
     - **Jedi**: For semantic code understanding, symbol resolution, and basic
       call graph construction.
-    - **CodeQL** (optional): For enhanced call graph resolution and more
-      accurate inter-procedural analysis.
+    - **PyCG**: For call-graph construction.
     - **Tree-sitter**: For fast syntactic parsing and AST operations.
 
 Key capabilities include:
@@ -183,7 +182,6 @@ class PythonAnalysis:
                 eager_analysis=eager_analysis,
                 cache_dir=cache_path,
                 target_files=target_files,
-                use_codeql=getattr(cfg, "use_codeql", True),
                 use_ray=getattr(cfg, "use_ray", False),
             )
 
@@ -370,7 +368,7 @@ class PythonAnalysis:
 
         The call graph is built using:
             - Jedi for semantic call resolution
-            - CodeQL (if enabled) for enhanced inter-procedural analysis
+            - PyCG for inter-procedural call-graph construction
 
         Returns:
             A ``networkx.DiGraph`` where:
@@ -380,9 +378,8 @@ class PythonAnalysis:
                 - Edge attributes may include call site information
 
         Note:
-            The completeness of the call graph depends on the analysis
-            configuration. With ``use_codeql=True``, more call relationships
-            are typically discovered at the cost of longer analysis time.
+            The completeness of the call graph depends on the analysis backend
+            (Jedi plus PyCG in codeanalyzer-python 0.3.0).
 
         See Also:
             :meth:`get_callers`: For finding callers of a specific method.

--- a/cldk/core.py
+++ b/cldk/core.py
@@ -25,8 +25,8 @@ parsers, and sanitization utilities.
 The CLDK supports the following languages:
     - **Java**: Full static analysis via CodeAnalyzer backend, including symbol
       tables, call graphs, and code metrics.
-    - **Python**: Static analysis via codeanalyzer-python backend with optional
-      CodeQL-augmented call graph resolution.
+    - **Python**: Static analysis via codeanalyzer-python backend (Jedi plus
+      PyCG call-graph construction).
     - **C**: Basic analysis via libclang for parsing and extracting code structure.
 
 Typical usage involves instantiating :class:`CLDK` with a target language, then
@@ -252,7 +252,6 @@ class CLDK:
         analysis_backend_path: str | None = None,
         analysis_json_path: str | Path | None = None,
         cache_dir: str | Path | None = None,
-        use_codeql: bool = True,
         use_ray: bool = False,
         neo4j_config: "Neo4jConnectionConfig | None" = None,
     ) -> JavaAnalysis | PythonAnalysis | CAnalysis | TypeScriptAnalysis:
@@ -300,7 +299,7 @@ class CLDK:
         elif self.language == "python":
             if source_code is not None:
                 raise CldkInitializationException("source_code mode is not supported for Python; please pass project_path.")
-            backend = neo4j_config if neo4j_config is not None else PyCodeAnalyzerConfig(cache_dir=cache_root, use_codeql=use_codeql, use_ray=use_ray)
+            backend = neo4j_config if neo4j_config is not None else PyCodeAnalyzerConfig(cache_dir=cache_root, use_ray=use_ray)
             return CLDK.python(
                 project_path=project_path,
                 analysis_level=analysis_level,

--- a/cldk/utils/exceptions/__init__.py
+++ b/cldk/utils/exceptions/__init__.py
@@ -21,13 +21,9 @@ Exceptions package
 from .exceptions import (
     CldkInitializationException,
     CodeanalyzerExecutionException,
-    CodeQLDatabaseBuildException,
-    CodeQLQueryExecutionException,
 )
 
 __all__ = [
-    "CodeQLDatabaseBuildException",
-    "CodeQLQueryExecutionException",
     "CodeanalyzerExecutionException",
     "CldkInitializationException",
 ]

--- a/cldk/utils/exceptions/exceptions.py
+++ b/cldk/utils/exceptions/exceptions.py
@@ -23,8 +23,6 @@ The exceptions are organized by category:
     - **Initialization Errors**: :class:`CldkInitializationException`
     - **Analysis Backend Errors**: :class:`CodeanalyzerExecutionException`,
       :class:`CodeanalyzerUsageException`
-    - **CodeQL Errors**: :class:`CodeQLDatabaseBuildException`,
-      :class:`CodeQLQueryExecutionException`
 
 All exceptions inherit from Python's built-in :class:`Exception` class and
 include a descriptive message attribute.
@@ -84,75 +82,6 @@ class CodeanalyzerExecutionException(Exception):
         Args:
             message: A descriptive error message explaining what went wrong
                 during CodeAnalyzer execution.
-        """
-        self.message = message
-        super().__init__(self.message)
-
-
-class CodeQLDatabaseBuildException(Exception):
-    """Exception raised for errors during CodeQL database building.
-
-    This exception is raised when the CodeQL database creation fails.
-    CodeQL databases are used for enhanced call graph analysis in Python.
-    Common causes include:
-        - CodeQL CLI not installed or not on PATH
-        - Invalid project structure for CodeQL
-        - Insufficient disk space
-        - Build errors in the target project
-
-    Attributes:
-        message (str): A descriptive error message explaining the
-            database build failure.
-
-    Note:
-        This exception is primarily relevant for Python analysis when
-        ``use_codeql=True`` is specified.
-
-    See Also:
-        :class:`~cldk.analysis.python.PythonAnalysis`: Python analysis
-            that may use CodeQL.
-    """
-
-    def __init__(self, message: str) -> None:
-        """Initialize the exception with a descriptive message.
-
-        Args:
-            message: A descriptive error message explaining what went wrong
-                during CodeQL database creation.
-        """
-        self.message = message
-        super().__init__(self.message)
-
-
-class CodeQLQueryExecutionException(Exception):
-    """Exception raised for errors during CodeQL query execution.
-
-    This exception is raised when a CodeQL query fails to execute against
-    a CodeQL database. Common causes include:
-        - Invalid query syntax
-        - Query timeout
-        - Database corruption
-        - Incompatible CodeQL version
-
-    Attributes:
-        message (str): A descriptive error message explaining the
-            query execution failure.
-
-    Note:
-        This exception is primarily relevant for Python analysis when
-        ``use_codeql=True`` is specified.
-
-    See Also:
-        :class:`CodeQLDatabaseBuildException`: Related exception for
-            database creation failures.
-    """
-
-    def __init__(self, message: str) -> None:
-        """Initialize the exception with a descriptive message.
-
-        Args:
-            message: A descriptive error message explaining what went wrong
-                during CodeQL query execution.
         """
         self.message = message
         super().__init__(self.message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.3.0"
+version = "1.4.0"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "tree-sitter-javascript==0.23.1",
     "clang==17.0.6",
     "libclang==17.0.6",
-    "codeanalyzer-python==0.2.0",
+    "codeanalyzer-python==0.3.0",
     "codeanalyzer-typescript==0.4.3",
 ]
 
@@ -88,7 +88,7 @@ include = [
 
 [tool.backend-versions]
 codeanalyzer-java = "2.4.1"
-codeanalyzer-python = "0.2.0"
+codeanalyzer-python = "0.3.0"
 codeanalyzer-typescript = "0.4.3"
 
 ########################################

--- a/tests/analysis/python/test_python_analysis.py
+++ b/tests/analysis/python/test_python_analysis.py
@@ -37,35 +37,12 @@ def test_python_analysis_requires_inputs():
         CLDK(language="python").analysis()
 
 
-def test_use_codeql_forwarded_through_facade(monkeypatch, tmp_path):
-    """Regression: CLDK.analysis() must forward use_codeql to the backend.
-
-    Previously the façade dropped the flag, making CodeQL-augmented edges
-    unreachable through the public API (only Jedi-resolved edges returned).
-    """
-    captured = {}
-
-    class FakeBackend:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
-    monkeypatch.setattr("cldk.analysis.python.python_analysis.PyCodeanalyzer", FakeBackend)
-
-    CLDK(language="python").analysis(project_path=tmp_path, use_codeql=False)
-    assert captured["use_codeql"] is False
-
-    # CodeQL is the default; the façade must not silently drop it.
-    captured.clear()
-    CLDK(language="python").analysis(project_path=tmp_path)
-    assert captured["use_codeql"] is True
-
-
 def test_use_ray_forwarded_through_facade(monkeypatch, tmp_path):
     """Regression: CLDK.analysis() must forward use_ray down to the backend.
 
     use_ray is a Python-only option lifted all the way up to the public API
     (CLDK.analysis → PythonAnalysis → PyCodeanalyzer → AnalysisOptions.using_ray);
-    the façade must not silently drop it (mirrors the use_codeql guard).
+    the façade must not silently drop it.
     """
     captured = {}
 

--- a/tests/analysis/python/test_python_neo4j_backend.py
+++ b/tests/analysis/python/test_python_neo4j_backend.py
@@ -144,7 +144,7 @@ def backends(tmp_path_factory):
     (pkg / "models.py").write_text(MODELS_PY)
     (pkg / "service.py").write_text(SERVICE_PY)
 
-    ref = PyCodeanalyzer(project_dir=proj, analysis_level="call_graph", analysis_json_path=None, eager_analysis=True, use_codeql=False)
+    ref = PyCodeanalyzer(project_dir=proj, analysis_level="call_graph", analysis_json_path=None, eager_analysis=True)
 
     # Load the graph out of band (in-process), exactly as a populator job would.
     opts = AnalysisOptions(
@@ -152,7 +152,6 @@ def backends(tmp_path_factory):
         emit=EmitTarget.NEO4J,
         app_name=APP_NAME,
         rebuild_analysis=True,
-        using_codeql=False,
         neo4j_uri=NEO4J_URI,
         neo4j_user=NEO4J_USER,
         neo4j_password=NEO4J_PASSWORD,

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "cldk"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "clang" },
@@ -346,7 +346,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "clang", specifier = "==17.0.6" },
-    { name = "codeanalyzer-python", specifier = "==0.2.0" },
+    { name = "codeanalyzer-python", specifier = "==0.3.0" },
     { name = "codeanalyzer-typescript", specifier = "==0.4.3" },
     { name = "libclang", specifier = "==17.0.6" },
     { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.14,<7" },
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "codeanalyzer-python"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jedi" },
@@ -405,16 +405,18 @@ dependencies = [
     { name = "numpy" },
     { name = "packaging" },
     { name = "pandas" },
+    { name = "pycg" },
     { name = "pydantic" },
     { name = "ray" },
     { name = "requests" },
     { name = "rich" },
     { name = "typer" },
     { name = "typing-extensions" },
+    { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/54/25a48b6c5d39c11be6b1fd222e7126b8b2f75b9a44bfe0bde5b0d3c6d943/codeanalyzer_python-0.2.0.tar.gz", hash = "sha256:0657dc0062bbbe30c14fee59b294e62aa7e006b94d872bb3ef5cb34f6d4c5f0e", size = 68804, upload-time = "2026-06-20T19:57:52.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/04/9feef38fdd748190e1c9c17a6bb208269f69c575cf1e36138329f60e1580/codeanalyzer_python-0.3.0.tar.gz", hash = "sha256:cbac189c3e296476305df25c93d2538c1cce56e456c6a8d8417cd3fdba5d2add", size = 92752, upload-time = "2026-06-27T17:29:20.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/4c/0b680068f63885568160484153254abca8598aa738214b9f2513e55246e6/codeanalyzer_python-0.2.0-py3-none-any.whl", hash = "sha256:37f27d2b8925f9acc10c6494c0105795d7fac651be343beac61c83a0fc36de9a", size = 71371, upload-time = "2026-06-20T19:57:51.896Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/eb/18c94c2f5a25e6b0d348b12a5150f97ae8b8279ad6a937dc47dfb3982d5c/codeanalyzer_python-0.3.0-py3-none-any.whl", hash = "sha256:37b7b2d9f8afdb65a5c49849f0cbf5b33e692e4dc51aa9e8f33b68427624785d", size = 84983, upload-time = "2026-06-27T17:29:18.845Z" },
 ]
 
 [[package]]
@@ -1576,6 +1578,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycg"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/ce/b438f7066610fd24c03fee5c92dfc8930c5f4e9613480b0e337c7ead2b51/pycg-0.0.8.tar.gz", hash = "sha256:644b4df4346b393ca29450223da12598a6e6ad51fcfb1c218330b774f643a6c1", size = 58703, upload-time = "2023-11-26T06:59:42.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/ee/3db86c684ae05d43f0777cc0d3739fd9f000827b4baa774f12ccab3200aa/pycg-0.0.8-py3-none-any.whl", hash = "sha256:90109b8b787d4496c2198576b0bb08ee5872e1a9a1d1ca557cb856c6798ec0da", size = 56979, upload-time = "2023-11-26T06:59:40.376Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2452,6 +2463,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/8e/2777bf40df3c634f2a522baaa2995d2bd5901461fc5d8730c04c39fa6c75/uv-0.11.25.tar.gz", hash = "sha256:458e731778e7b5cc870710397859c23e766703e7bc0695f23b3eb15080745ba6", size = 4329198, upload-time = "2026-06-27T00:49:00.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/a7/dc836daca0db76178cfe4e40ee95fa2c5f96a3d7b3cda0bdde5291aef8b8/uv-0.11.25-py3-none-linux_armv6l.whl", hash = "sha256:d6f965a79fc7539a12139ce981caa0cbf7d9d3bd4ea3daadaf174ab4d7fb6e42", size = 25153689, upload-time = "2026-06-27T00:48:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d60eabb616db232ed0e682c55d858d0980175a92336429c4e0ee82a160e6/uv-0.11.25-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:610650cbaa0a9b18015da39d2c28d736d287a5a124e49296d8fdef5e4022e980", size = 24149272, upload-time = "2026-06-27T00:48:13.917Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/fd/9f72373e340c6abcd3eb9257d69b442434b65e90e1f7f53f333abdac11b2/uv-0.11.25-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f7a78fc8d0c5e764e9fa39c99066db47a0bc465b023feed90812e3c0a6b5eb0d", size = 22885453, upload-time = "2026-06-27T00:48:16.641Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c1/7cbb3f6b4a021ce7c1c453d1412d3b4b68d7d7585d15d91a57e9ab0a317e/uv-0.11.25-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:e3480640983e0b8e509eeb67882837e620bdd820f8776948a5f13ebbb4481d04", size = 24935172, upload-time = "2026-06-27T00:48:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d4/862a534ab4aae28ad2c9145ea5af3021eefe225e4e1c983278bb34b53b9e/uv-0.11.25-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:b180b12237b4e04692491fc6796584a9a8bdf4c7332bd2a769caf096b97885d0", size = 24665125, upload-time = "2026-06-27T00:48:22.408Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2a/70ef2f2a212d89d23f90e1c8017c080fae93bec21cd9f14795498a6e6f89/uv-0.11.25-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:69d14ffd0a4b050f8a70f64aacb09b8dfdfb1cb30a6351fb17b48f273f95c58c", size = 24653836, upload-time = "2026-06-27T00:48:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/a7beea057778f092daa5aeda7aeb3f8bfa78f4a0622245adb449fdbb3d20/uv-0.11.25-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:61ef11d9967a38109e6e8e3d20d1f743fa08033c32bce274d6ccd9a9abb5d305", size = 26069304, upload-time = "2026-06-27T00:48:28.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e8/bb8ab595a27035b565cedd5d601ae2b85cf6aba6f68cd6a97eae88dd7250/uv-0.11.25-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3febca65ec5bc336ddaf7e4f724704f2c894c16839723df14865ee00b4acf38d", size = 26992784, upload-time = "2026-06-27T00:48:30.584Z" },
+    { url = "https://files.pythonhosted.org/packages/17/90/bbfa0653e992877e5ea78ab3186fb6a5a122ebef5913b6809ef6d06fcf9b/uv-0.11.25-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:850ba0018ff170c3a9baaf9b5fe8b23393b6b77ee4ea6b2e2315fdb8d7c388f7", size = 26151002, upload-time = "2026-06-27T00:48:33.739Z" },
+    { url = "https://files.pythonhosted.org/packages/91/01/f5a01fd777ce501cc59eb71775f3bbacac258a65a64939f07804c2279c98/uv-0.11.25-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2bc05e17ae3e1f232abf93e7dcfb3b68702dfcde34a00c29cbce7e07d1ecbfb", size = 26334122, upload-time = "2026-06-27T00:48:36.247Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c4/f8b3b6b1bb48a452d98c02909e229f7ae317300618d6dc334c883742339e/uv-0.11.25-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:57fbd47e924242fd347d0c209d95711d8ea61db8d8780962d0f30ccde2c854a3", size = 25055505, upload-time = "2026-06-27T00:48:39.418Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7d/aece221faba22804d8b4f913903358dc2d45193babf2a44a49f79eadd25b/uv-0.11.25-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:f42de9e7d63a28a4fe76a522077813656de38b5acda20b4db63857d260c1ff13", size = 25660097, upload-time = "2026-06-27T00:48:42.398Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7d/b835ed56eab281054efbfbcbbe1249621908c6e4c721a878904cbed2f418/uv-0.11.25-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2c1cfe97dce56c997dfa3214bdb8955b7b34cceea7505520185e22ad99c0eb6b", size = 25759374, upload-time = "2026-06-27T00:48:45.069Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/fd/28c990fd18330aa01383bae738be113f4ac5d9d414f92790947326c6781c/uv-0.11.25-py3-none-musllinux_1_1_i686.whl", hash = "sha256:fbff70ae9fa4da9fb6823ae4fdaf77a65c9520e13b6d1d0241ba56e4b121b7aa", size = 25329343, upload-time = "2026-06-27T00:48:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/70/48/16ff9dbe5f308cb547e227971cbcaf3c905797da12a4116b620e2acc09cb/uv-0.11.25-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:41b37e724f41eb4c3794bbdd82ddeebb4b5850d4ada8cccb2906ef9e5aa0f83b", size = 26477125, upload-time = "2026-06-27T00:48:50.251Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8b/4146a55d3ee6b2b67c3dece3ef6be220c443abafc2dc56baa2f74d6b36a8/uv-0.11.25-py3-none-win32.whl", hash = "sha256:86d4759fec9b46f61944d6e9ef1f5eaa2c5fbe2db5ddb59492d9174b08fcf39c", size = 23896598, upload-time = "2026-06-27T00:48:53.01Z" },
+    { url = "https://files.pythonhosted.org/packages/64/66/784f9fb457b640dbb96cdd175f4902235b42ffe740dbaee9ea5fc649d8b2/uv-0.11.25-py3-none-win_amd64.whl", hash = "sha256:560b0fbaa6356af533923a349658c21d4f410d16e835787d8a05da451d4ee859", size = 26862205, upload-time = "2026-06-27T00:48:55.667Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cb/d7bb121261db0b829f38b1e86b80d8103afd050b8a5c5c9fe4a988d2f1fc/uv-0.11.25-py3-none-win_arm64.whl", hash = "sha256:79f166cd1b84f855e9d2768221d59b403869648289fd884d58ad4299edfb4d9e", size = 25153588, upload-time = "2026-06-27T00:48:58.495Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades `codeanalyzer-python` `0.2.0 → 0.3.0` and removes CodeQL from CLDK entirely. Closes #185. Releases as **1.4.0**.

## Motivation and Context
`codeanalyzer-python` 0.3.0 **dropped CodeQL** in favor of **PyCG** for call-graph construction and removed the `using_codeql` option from `AnalysisOptions`. CLDK's in-process Python backend still passed it, so *every* real Python analysis raised:

```
TypeError: AnalysisOptions.__init__() got an unexpected keyword argument 'using_codeql'
```

Since CodeQL no longer exists upstream, CLDK's `use_codeql` knob has no backing implementation and is removed rather than kept as a no-op. See #185 for the full diagnosis.

## What changed
- **Pin** `codeanalyzer-python` `0.2.0 → 0.3.0` (+ `uv.lock`).
- **Removed `use_codeql` from the public surface:** `PyCodeAnalyzerConfig.use_codeql`, the deprecated `CLDK(language).analysis(use_codeql=...)` parameter, the `PyCodeanalyzer(use_codeql=...)` argument, and the facade forwarding. Stopped passing `using_codeql` to `AnalysisOptions`.
- **Removed CodeQL exception classes** `CodeQLDatabaseBuildException` / `CodeQLQueryExecutionException` and their re-exports.
- **Scrubbed CodeQL** from docstrings, the README (engine list, backend table, cache note, architecture diagram), and the Java `_jdk.py` loader comments; the Python backend is now described as **Jedi + PyCG**.
- **Tests:** dropped the obsolete `use_codeql` forwarding test; fixed the Neo4j parity fixture to not pass `using_codeql`.

## How Has This Been Tested?
- Ran the **real 0.3.0 analyzer end-to-end** through `PyCodeanalyzer` over a sample project — no `TypeError`; the bulk accessors (`get_callables_overview`, `get_decorated_callables`, ...) work against real 0.3.0 output.
- `tests/analysis/python` + `tests/models/python`: **24 passed, 6 skipped** (Neo4j-gated).
- Verified zero remaining `codeql` references in source (the only hits are in a local, gitignored `.codeanalyzer` cache that is never committed).

## Breaking Changes
**Yes.** Removes the public `use_codeql` option and the two CodeQL exception classes. Call-graph results may differ (PyCG vs CodeQL-augmented Jedi). Released as 1.4.0 with a CHANGELOG **Removed (BREAKING)** entry.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Commits: `feat(python)!: upgrade to codeanalyzer-python 0.3.0 and remove CodeQL`, then `chore(release): 1.4.0`. Tagging/publishing is left to the release workflow off the merged version bump.
