### PR TITLE
chore: add supported-languages section and AGENTS.md/GEMINI.md symlinks to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,9 @@ poetry.lock
 
 # CLDK files
 .codeanalyzer
+
+# Agent guide files — un-ignore past the global ~/.gitignore_global rule that
+# excludes AGENTS.md, so the CLAUDE.md/AGENTS.md/GEMINI.md guide is tracked.
+!CLAUDE.md
+!AGENTS.md
+!GEMINI.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 Agent guidance for `codellm-devkit/python-sdk`.
 
+## Supported languages
+
+The SDK exposes one static factory method per language on `CLDK`. Each returns a facade backed by
+a per-language `<Lang>AnalysisBackend` ABC, with a local codeanalyzer backend and (where available)
+an optional read-only Neo4j backend — selected by the *type* of the `backend=` config object.
+
+| Language | Entry point | Local backend | Neo4j backend | Models |
+|----------|-------------|---------------|---------------|--------|
+| Java | `CLDK.java(...)` | `JCodeanalyzer` (bundled JAR, subprocess) | `JNeo4jBackend` | `cldk/models/java/` |
+| Python | `CLDK.python(...)` | `PyCodeanalyzer` (in-process `codeanalyzer-python`) | `PyNeo4jBackend` | re-exported from `codeanalyzer-python` |
+| TypeScript | `CLDK.typescript(...)` | `TSCodeanalyzer` (`codeanalyzer-typescript` binary, subprocess) | `TSNeo4jBackend` | `cldk/models/typescript/` |
+| C | `CLDK.c(...)` | libclang (in-process, syntactic only) | — | `cldk/models/c/` |
+
+The legacy `CLDK(language="<lang>").analysis(...)` entry still works as a compat shim. Adding a
+language means a new factory method + facade + backend ABC/impl(s) + models + tests — **update this
+table in the same change**.
+
 ## I implement features myself — you assist
 
 For feature work, **I write the implementation myself** to stay fluent in my own SDK. Act as a helper, not the author:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

Closes #191.

- Adds a **Supported languages** section to `CLAUDE.md` — a table of the four wired languages (`java`, `python`, `typescript`, `c`) with their `CLDK.<lang>()` entry point, local + optional read-only Neo4j backends, and model locations. Notes that adding a language must update the table in the same change.
- Adds **`AGENTS.md` and `GEMINI.md`** as relative symlinks to `CLAUDE.md` so Claude Code, the generic-agent convention, and Gemini all read one source of truth. (AGENTS.md is force-added past the global gitignore, matching the sibling analyzer repos.)

## Test plan

Docs/symlink-only change. Verified both symlinks resolve to `CLAUDE.md` and are tracked in the commit.