### PR TITLE
chore(release): 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.4.1] - 2026-07-14
+
+### Fixed
+- **Module-level functions are now resolvable through `get_method` (Python and TypeScript, both
+  backends).** Previously `get_method` searched class scope only, so module-level functions were
+  unreachable and `get_all_callers`/`get_all_callees` returned a silent empty result for them even
+  when the call graph contained the edges. The scope argument now accepts a module name as well as
+  a qualified class name; callers/callees, `get_method_parameters`, and comment lookups inherit the
+  fix. (#250, #251)
+- **Java lookups no longer crash on a miss.** `get_method`/`get_class`/`get_java_file` are honestly
+  annotated `... | None` (ABC, both backends, and the public facade), `get_method_parameters`
+  returns an empty list instead of raising `AttributeError` for an unknown class or signature, and
+  all internal call-graph/comment lookups are guarded. No behavior change on successful lookups.
+  (#252)
+
 ## [v1.4.0] - 2026-06-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.4.0"
+version = "1.4.1"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "cldk"
-version = "1.3.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "clang" },


### PR DESCRIPTION
Release 1.4.1 — patch release carrying the three lookup fixes (#250, #251, #252).

- Bump version to 1.4.1 (pyproject + uv.lock, which was still recording 1.3.0)
- CHANGELOG entry for v1.4.1

Gates on the release content (main@e7e289d): python 35 passed/6 skipped; typescript 49 passed/19 skipped (golden fixture present); java 127 passed/4 skipped/11 pre-existing environment failures (JDK-download/native-binary, identical on v1.4.0).