### PR TITLE
chore(release): 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.4.2] - 2026-07-14
+
+### Fixed
+- **Intra-class method calls resolve to the method again.** Upgraded `codeanalyzer-python`
+  0.3.0 → 0.3.1, which fixes callee resolution for `self._method(...)` calls: the call graph
+  previously pointed such edges at the *class* node (truncating call chains at their deepest
+  hop) and could omit receiver-method edges entirely. Call-site `callee_signature` now names
+  the method, and `PyCallsite` gains an additive `arguments` field.
+  (codellm-devkit/codeanalyzer-python#94, #260)
+
 ## [v1.4.1] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.4.1"
+version = "1.4.2"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "cldk"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "clang" },


### PR DESCRIPTION
Release 1.4.2 — patch carrying the codeanalyzer-python 0.3.1 uptake (#261): intra-class callee resolution fixed upstream (codellm-devkit/codeanalyzer-python#94).

Gate on release content: python analysis + models suites — 41 passed, 6 skipped, 0 failed against 0.3.1.