### PR TITLE
fix(typescript): External-node reconstruction conforms to the slim TSExternalSymbol model

### DIFF
--- a/cldk/analysis/typescript/neo4j/reconstruct.py
+++ b/cldk/analysis/typescript/neo4j/reconstruct.py
@@ -173,11 +173,12 @@ def enum_member(name: str, value: str | None) -> TSEnumMember:
 
 
 def external(props: Props) -> TSExternalSymbol:
+    # Slim by design (#231): the model carries name+module only. The graph node's
+    # ``signature`` is its merge key and becomes the ``external_symbols`` map key at the
+    # call site; ``kind`` does not exist in the analyzer's published Neo4j schema.
     return TSExternalSymbol(
-        signature=props.get("signature", ""),
         name=props.get("name", ""),
         module=props.get("module", ""),
-        kind=props.get("kind", "unknown"),
     )
 
 

--- a/tests/analysis/typescript/test_typescript_external_reconstruct.py
+++ b/tests/analysis/typescript/test_typescript_external_reconstruct.py
@@ -1,0 +1,62 @@
+################################################################################
+# Copyright IBM Corporation 2024, 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Regression tests for #231: reconstructing External (phantom) nodes from Neo4j
+properties must conform to the slim TSExternalSymbol model (name + module only) —
+the graph node legitimately carries signature/kind properties, and the
+reconstructor must not forward them into an extra='forbid' model."""
+
+from unittest.mock import patch
+
+from cldk.analysis.typescript.neo4j import reconstruct as R
+from cldk.analysis.typescript.neo4j.neo4j_backend import TSNeo4jBackend
+from cldk.models.typescript import TSExternalSymbol
+
+
+def test_external_reconstructs_from_full_graph_props():
+    """A real External node's property bag (signature, kind, _module included) reconstructs."""
+    sym = R.external(
+        {
+            "signature": "commander.parse",
+            "name": "parse",
+            "module": "commander",
+            "kind": "external",
+            "_module": "app",
+        }
+    )
+    assert isinstance(sym, TSExternalSymbol)
+    assert sym.name == "parse"
+    assert sym.module == "commander"
+
+
+def test_external_reconstructs_with_empty_signature():
+    """The reported repro: an empty-signature External node must not raise."""
+    sym = R.external({"signature": "", "name": "", "module": "", "kind": "unknown"})
+    assert isinstance(sym, TSExternalSymbol)
+
+
+def test_get_external_symbols_end_to_end_via_stubbed_run():
+    """Backend-level: get_external_symbols reconstructs every returned row, keyed by signature."""
+    rows = [
+        {"p": {"signature": "commander.parse", "name": "parse", "module": "commander", "kind": "external"}},
+        {"p": {"signature": "fs.readFileSync", "name": "readFileSync", "module": "fs", "kind": "external"}},
+    ]
+    backend = TSNeo4jBackend.__new__(TSNeo4jBackend)
+    backend._modules = ["app"]
+    with patch.object(TSNeo4jBackend, "_run", return_value=rows):
+        out = backend.get_external_symbols()
+    assert set(out) == {"commander.parse", "fs.readFileSync"}
+    assert out["commander.parse"].module == "commander"


### PR DESCRIPTION
Closes #231 (reopened — the earlier close deferred to 2.x work that doesn't exist yet; this is the live 1.x fix).

TSNeo4jBackend.get_external_symbols() raised ValidationError('extra_forbidden') for EVERY External (phantom) node — the default configuration on real apps — because reconstruct.external() passed signature and kind into the extra='forbid' TSExternalSymbol model, which declares only name+module. Reproduced with signature='' per the report.

Fix conforms the reconstructor to both contracts at once: the SDK model is slim by design (map key IS the signature), and the analyzer's published Neo4j schema (codeanalyzer-typescript schema.neo4j.json, External: {signature, name, module}) has no kind property at all — the reconstructor was fabricating it. No information loss: signature remains the external_symbols map key at the call site.

TDD: 3 regression tests (full graph props, empty-signature repro, backend-level via stubbed _run) — RED on main, GREEN after. TS suite at worktree baseline (29 passed, 19 skipped, 23 pre-existing gitignored-fixture errors, #255).

Rides 1.4.3 with #263.