### PR TITLE
fix: bundle codeanalyzer-java JAR in published wheels (#284)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,25 @@ jobs:
       - name: Build Package
         run: uv build
 
+      - name: Verify the codeanalyzer JAR is bundled
+        # Guard against the hatchling/.gitignore regression (issue #284): a jarless wheel
+        # installs fine but fails at runtime with "codeanalyzer jar not found". Fail the
+        # release here rather than publish a broken artifact to PyPI.
+        run: |
+          set -euo pipefail
+          jar_re='codeanalyzer/jar/codeanalyzer-[0-9][^/]*\.jar$'
+          ok=1
+          for f in dist/*.whl; do
+            unzip -l "$f" | grep -qE "$jar_re" || { echo "::error::$f is missing the codeanalyzer JAR"; ok=0; }
+          done
+          for f in dist/*.tar.gz; do
+            tar tzf "$f" | grep -qE "$jar_re" || { echo "::error::$f is missing the codeanalyzer JAR"; ok=0; }
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "Refusing to publish a jarless release."; exit 1
+          fi
+          echo "codeanalyzer JAR present in wheel and sdist ✓"
+
       - name: Read Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Published wheels bundle the `codeanalyzer-java` JAR again.** Every hatchling-built wheel/sdist
+  since v1.2.0 shipped without the JAR, so `pip install cldk` + `CLDK.java(...)` raised
+  `CodeanalyzerExecutionException: codeanalyzer jar not found`. The root `.gitignore` `*.jar` rule
+  was applied at build time while the nested `!codeanalyzer-*.jar` negation (which keeps the JAR in
+  git) was not honored, silently dropping the JAR from any build run inside a git repo — i.e. CI. A
+  `[tool.hatch.build] artifacts` rule force-includes it, and the release workflow now fails if a
+  built artifact is missing the JAR. (#284)
+
 ## [v1.4.3] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,13 @@ test = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# The codeanalyzer-java JAR is force-included here: it lives under a `*.jar` .gitignore
+# (re-included for git via a nested `!codeanalyzer-*.jar`), but hatchling honors the root
+# ignore and not the nested negation, so without this it is silently dropped from every
+# wheel/sdist built inside a git repo (i.e. in CI). See issue #284.
+[tool.hatch.build]
+artifacts = ["cldk/analysis/java/codeanalyzer/jar/*.jar"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["cldk"]
 


### PR DESCRIPTION
Fixes #284.

## Problem

Every hatchling-built wheel/sdist since **v1.2.0** ships **without** the bundled
`codeanalyzer-java` JAR. After a plain `pip install cldk`, `CLDK.java(...)` fails at runtime with
`CodeanalyzerExecutionException: codeanalyzer jar not found`. Verified on PyPI — 1.4.0–1.4.3 and
2.0.0rc1 wheels are all ~176 KB (jarless); the setuptools-era wheels (≤ 1.1.3) were 26–56 MB.

## Root cause

- Root `.gitignore` has `*.jar`; the nested `cldk/analysis/java/codeanalyzer/jar/.gitignore`
  re-includes the JAR with `!codeanalyzer-*.jar`. **git** honors that negation (the JAR is tracked
  in every tag); **hatchling** applies the root `*.jar` at build time but does **not** honor the
  nested negation, so it drops the JAR.
- Hatchling only applies `.gitignore` exclusion when a `.git` dir is present — which CI has — so a
  `git archive`/source-tarball build keeps the JAR while the CI build drops it. That false negative
  hid the bug for 5 releases.
- `release.yml` already injects the JAR before `uv build`; hatchling discarded it anyway.

## Fix

- `pyproject.toml`: `[tool.hatch.build] artifacts = ["cldk/analysis/java/codeanalyzer/jar/*.jar"]`
  force-includes the VCS-ignored JAR in both wheel and sdist.
- `release.yml`: a **"Verify the codeanalyzer JAR is bundled"** step fails the release before
  publishing if any built artifact is missing the JAR — so this can never silently regress again.

## Verification

Built in the real repo (has `.git` → CI condition):

```
uv build
# before: cldk-*-py3-none-any.whl = 176081 B  -> NO jar  (byte-identical to published 1.4.3)
# after:  cldk-*-py3-none-any.whl = 32416976 B -> cldk/analysis/java/codeanalyzer/jar/codeanalyzer-2.4.1.jar
```

Both wheel and sdist now contain the JAR; the guard grep passes on both.

## Follow-up

1.4.3 is already published jarless and cannot be re-uploaded — this needs a **1.4.4** release cut
after merge.
