### PR TITLE
chore(release): 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.4.4] - 2026-07-22
+
 ### Fixed
 - **Published wheels bundle the `codeanalyzer-java` JAR again.** Every hatchling-built wheel/sdist
   since v1.2.0 shipped without the JAR, so `pip install cldk` + `CLDK.java(...)` raised

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldk"
-version = "1.4.3"
+version = "1.4.4"
 description = "The official Python SDK for Codellm-Devkit."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "cldk"
-version = "1.4.3"
+version = "1.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "clang" },


### PR DESCRIPTION
Release **1.4.4**.

Cuts the release for the packaging fix in #285 (issue #284): published wheels/sdists once again bundle the `codeanalyzer-java` JAR. Tagging `v1.4.4` after merge will build (JAR now included), the new release guard will confirm it, and publish to PyPI.

- Bump version `1.4.3` → `1.4.4`
- Move `## [Unreleased]` → `## [v1.4.4]` in CHANGELOG
- Refresh `uv.lock`