### PR TITLE
test: fix stale conftest docstring for the retired native binary (#292)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,8 +66,8 @@ def analysis_json(analysis_json_fixture) -> str:
 def codeanalyzer_backend_path():
     """Backend-path override for the Java analyzer in tests.
 
-    Returns None so the analyzer uses its default: the JVM-free native binary shipped in the
-    ``codeanalyzer-java`` PyPI package (``python -m codeanalyzer_java``).
+    Returns None so the analyzer uses its default: the ``codeanalyzer-*.jar`` bundled under
+    ``cldk/analysis/java/codeanalyzer/jar/``, run on a cached JDK (``[java, -jar, <jar>]``).
     """
     return None
 


### PR DESCRIPTION
Fixes #292. Docstring-only follow-up to #290 — `codeanalyzer_backend_path` documented the retired `python -m codeanalyzer_java` native binary; corrected to the bundled-jar default. Fixture behaviour unchanged (still returns `None`).