### PR TITLE
Omit None-code callables from Python get_method_bodies

### DIFF
--- a/cldk/analysis/python/backend.py
+++ b/cldk/analysis/python/backend.py
@@ -156,7 +156,8 @@ class PythonAnalysisBackend(ABC):
     @abstractmethod
     def get_method_bodies(self, signatures: List[str]) -> Dict[str, str]:
         """Source bodies for the given callable signatures, keyed by signature. Signatures with no
-        matching callable are omitted."""
+        matching callable are omitted, as are callables whose ``code`` is ``None`` (e.g. synthesized
+        callables the analyzer emits with no source text) — every returned value is a real ``str``."""
 
     @abstractmethod
     def get_decorated_callables(self, markers: List[str]) -> List[PyCallableOverview]:

--- a/cldk/analysis/python/codeanalyzer/codeanalyzer.py
+++ b/cldk/analysis/python/codeanalyzer/codeanalyzer.py
@@ -583,9 +583,10 @@ class PyCodeanalyzer(PythonAnalysisBackend):
         return [_overview(c, class_sig, kind) for c, class_sig, kind in self._iter_callables()]
 
     def get_method_bodies(self, signatures: List[str]) -> Dict[str, str]:
-        """Return ``{signature: code}`` for the requested signatures that exist."""
+        """Return ``{signature: code}`` for the requested signatures that exist and have a body
+        (omits callables whose ``code`` is ``None``)."""
         wanted = set(signatures)
-        return {c.signature: c.code for c, _, _ in self._iter_callables() if c.signature in wanted}
+        return {c.signature: c.code for c, _, _ in self._iter_callables() if c.signature in wanted and c.code is not None}
 
     def get_decorated_callables(self, markers: List[str]) -> List[PyCallableOverview]:
         """Return overviews of callables decorated with any of ``markers``."""

--- a/cldk/analysis/python/neo4j/neo4j_backend.py
+++ b/cldk/analysis/python/neo4j/neo4j_backend.py
@@ -498,12 +498,12 @@ class PyNeo4jBackend(PythonAnalysisBackend):
 
     def get_method_bodies(self, signatures: List[str]) -> Dict[str, str]:
         rows = self._run(
-            "MATCH (c:PyCallable) WHERE c._module IN $mods AND c.signature IN $sigs "
+            "MATCH (c:PyCallable) WHERE c._module IN $mods AND c.signature IN $sigs AND c.code IS NOT NULL "
             "RETURN c.signature AS signature, c.code AS code",
             mods=self._modules,
             sigs=list(signatures),
         )
-        return {r["signature"]: r.get("code") for r in rows}
+        return {r["signature"]: r["code"] for r in rows}
 
     def get_decorated_callables(self, markers: List[str]) -> List[PyCallableOverview]:
         rows = self._run(

--- a/cldk/analysis/python/python_analysis.py
+++ b/cldk/analysis/python/python_analysis.py
@@ -552,7 +552,8 @@ class PythonAnalysis:
 
         Returns:
             A dict mapping each signature to its source body. Signatures with no matching callable
-            are omitted.
+            are omitted, as are callables whose ``code`` is ``None`` — every returned value is a
+            real ``str``.
         """
         return self.backend.get_method_bodies(signatures)
 


### PR DESCRIPTION
Fixes the Python half of the bulk-accessor parity gap found during #298's review.

## Problem

The TypeScript bulk accessors ship `get_method_bodies` with a mechanical omission rule: a callable whose `code` is `None` is left out, so every value in the returned `Dict[str, str]` is a real `str`. Python passed `code` straight through, so a `PyCallable` with no source text yielded a `None` value — a violation of the declared `Dict[str, str]` contract.

## Change

Aligns Python upward to the TS rule, in both backends:

- **in-memory** (`codeanalyzer.py`) — filter on `c.code is not None`, matching the TS loop.
- **Neo4j** (`neo4j_backend.py`) — add `AND c.code IS NOT NULL` to the `MATCH` and index the row directly instead of `r.get("code")`, mirroring the TS Cypher exactly.

Both docstring layers (the ABC and the facade) now document the rule, as the TS side already does — the promise that every returned value is a real `str` is part of the contract, not an implementation detail.

## Verification

`tests/analysis/python/test_python_bulk_accessors.py` — 5 passed. (Running a single file trips the 50% global coverage gate at 40%; that's an artifact of the partial run, not a failure.)

Closes #301