### PR TITLE
Fix dead release test gate: use outcome, not conclusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,17 @@ jobs:
 
       - name: Run Tests
         id: test
+        # continue-on-error is deliberate: without it a red suite fails the job
+        # immediately and the tag-deletion step below never runs. It must be paired
+        # with `outcome` (not `conclusion`) in that step — see the comment there.
         continue-on-error: true
         run: uv run make test
 
       - name: Delete tag on failure
-        if: steps.test.conclusion == 'failure'
+        # MUST be `outcome`, not `conclusion`: continue-on-error rewrites `conclusion`
+        # to `success`, so `steps.test.conclusion == 'failure'` is never true and this
+        # step never fires. `outcome` preserves the step's real result.
+        if: steps.test.outcome == 'failure'
         run: |
           echo "Tests failed. Deleting tag ${GITHUB_REF#refs/tags/}..."
           git push --delete origin ${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
## Problem

`release.yml`'s test step sets `continue-on-error: true`, and the follow-up step gates on `steps.test.conclusion`:

```yaml
- name: Run Tests
  id: test
  continue-on-error: true
  run: uv run make test

- name: Delete tag on failure
  if: steps.test.conclusion == 'failure'
```

`continue-on-error: true` **rewrites `conclusion` to `success`** regardless of the real result. So `steps.test.conclusion == 'failure'` is never true, "Delete tag on failure" has never once fired, and a red test suite produces a green release that publishes to PyPI.

## Fix

Gate on `steps.test.outcome`, which preserves the step's actual result.

`continue-on-error` **stays** — removing it would fail the job immediately and the tag-deletion step could never run, which is the opposite of what's wanted. The two must be paired, so both halves now carry a comment saying why.

## Scope

This fixes the mechanical gate only. The other half of #255 — making the CI suite honestly green — is **not** addressed here, and turning a working gate on may now surface failures that were previously invisible. That is the point, but worth knowing before merging.

Refs #255
